### PR TITLE
Fixed caption on runOWASPScan parameter

### DIFF
--- a/pipelines/ci_pipeline.yaml
+++ b/pipelines/ci_pipeline.yaml
@@ -12,7 +12,7 @@ parameters:
   type: boolean
   default: true
 - name: runOWASPScan
-  displayName: Run tests
+  displayName: Run OWASP Scan
   type: boolean
   default: false
 - name: sonarqubeInstance


### PR DESCRIPTION
Fixed caption of runOWASPScan parameter (said "Run Tests" now says "Run OWASP Scan").
