### PR TITLE
Restored OWASP control to intended defaults

### DIFF
--- a/pipelines/ci_pipeline.yaml
+++ b/pipelines/ci_pipeline.yaml
@@ -11,10 +11,6 @@ parameters:
   displayName: Run tests
   type: boolean
   default: true
-- name: runOWASPScan
-  displayName: Run OWASP Scan
-  type: boolean
-  default: false
 - name: sonarqubeInstance
   displayName: 'Select SonarQube for v9.9 or SonarQubeLatest for 10.4'
   type: string
@@ -57,7 +53,6 @@ extends:
     sonarQubeProjectKey: ${{ variables.sonarQubeProjectKey }}
     sonarQubeProjectName: ${{ variables.sonarQubeProjectName }}
     runTests: ${{ parameters.runTests }}
-    runOWASPScan: ${{ parameters.runOWASPScan }}
     azureSubscription: $(azureSubscription)
     acrAzureContainerRegistryName: $(acr.azureContainerRegistryName)
     acrRepositoryName: $(acr.repositoryName)


### PR DESCRIPTION
The OWASP scanning was failing for everyone at the start of the migration so changes were made to allow this migration to proceed without being blocked by OWASP.

The OWASP scanning has been fixed since migrating.  This change is to restore the pipeline to it's original state.
