### PR TITLE
anti-virus-function-app-SonarQube 10.4

### DIFF
--- a/EPR.Antivirus/EPR.Antivirus.Application.UnitTests/Clients/ServiceBusQueueClientTests.cs
+++ b/EPR.Antivirus/EPR.Antivirus.Application.UnitTests/Clients/ServiceBusQueueClientTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace EPR.Antivirus.Application.UnitTests.Clients;
 
 using Application.Clients;
-using Application.Clients.Interfaces;
 using Azure.Messaging.ServiceBus;
 using Data.DTOs.ServiceBusQueue;
 using Data.Enums;
@@ -20,7 +19,7 @@ public class ServiceBusQueueClientTests
     private Mock<ServiceBusClient> _serviceBusClientMock;
     private Mock<IOptions<ServiceBusOptions>> _optionsMock;
 
-    private IServiceBusQueueClient _systemUnderTest;
+    private ServiceBusQueueClient _systemUnderTest;
 
     [TestInitialize]
     public void TestInitialize()

--- a/EPR.Antivirus/EPR.Antivirus.Application.UnitTests/Clients/SubmissionStatusApiClientTests.cs
+++ b/EPR.Antivirus/EPR.Antivirus.Application.UnitTests/Clients/SubmissionStatusApiClientTests.cs
@@ -3,7 +3,6 @@
 using System.Net;
 using System.Text.Json;
 using Application.Clients;
-using Application.Clients.Interfaces;
 using Data.DTOs.SubmissionStatusApi;
 using Data.Enums;
 using Data.Options;
@@ -25,7 +24,7 @@ public class SubmissionStatusApiClientTests
     private Mock<HttpMessageHandler> _httpMessageHandlerMock;
     private HttpClient _httpClient;
 
-    private ISubmissionStatusApiClient _systemUnderTest;
+    private SubmissionStatusApiClient _systemUnderTest;
 
     [TestInitialize]
     public void TestInitialize()
@@ -187,9 +186,9 @@ public class SubmissionStatusApiClientTests
         }
 
         var stringContent = content.ReadAsStringAsync().Result;
+        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
         var report = JsonSerializer.Deserialize<SubmissionEventRequest>(
-            stringContent,
-            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            stringContent, options);
 
         if (report is null)
         {

--- a/EPR.Antivirus/EPR.Antivirus.Application.UnitTests/Clients/SubmissionStatusApiClientTests.cs
+++ b/EPR.Antivirus/EPR.Antivirus.Application.UnitTests/Clients/SubmissionStatusApiClientTests.cs
@@ -19,6 +19,7 @@ public class SubmissionStatusApiClientTests
 {
     private const string PomContainerName = "pom-blob-container-name";
     private const string RegistrationContainerName = "registration-blob-container-name";
+    private static readonly JsonSerializerOptions Options = new() { PropertyNameCaseInsensitive = true };
     private readonly Mock<IOptions<BlobStorageOptions>> _blobStorageOptionsMock = new();
 
     private Mock<HttpMessageHandler> _httpMessageHandlerMock;
@@ -186,9 +187,8 @@ public class SubmissionStatusApiClientTests
         }
 
         var stringContent = content.ReadAsStringAsync().Result;
-        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
         var report = JsonSerializer.Deserialize<SubmissionEventRequest>(
-            stringContent, options);
+            stringContent, Options);
 
         if (report is null)
         {

--- a/EPR.Antivirus/EPR.Antivirus.Application.UnitTests/Services/AntiVirusServiceTests.cs
+++ b/EPR.Antivirus/EPR.Antivirus.Application.UnitTests/Services/AntiVirusServiceTests.cs
@@ -27,7 +27,7 @@ public class AntivirusServiceTests
     private Mock<ILoggingService> _loggingServiceMock;
     private Mock<IFeatureManager> _featureManagerMock;
 
-    private IAntivirusService _systemUnderTest;
+    private AntivirusService _systemUnderTest;
 
     [TestInitialize]
     public void TestInitialize()

--- a/EPR.Antivirus/EPR.Antivirus.Application.UnitTests/Services/BlobStorageServiceTests.cs
+++ b/EPR.Antivirus/EPR.Antivirus.Application.UnitTests/Services/BlobStorageServiceTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace EPR.Antivirus.Application.UnitTests.Services;
 
 using Application.Services;
-using Application.Services.Interfaces;
 using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
@@ -22,7 +21,7 @@ public class BlobStorageServiceTests
     private Mock<BlobServiceClient> _blobServiceClientMock;
     private Mock<IOptions<BlobStorageOptions>> _optionsMock;
 
-    private IBlobStorageService _systemUnderTest;
+    private BlobStorageService _systemUnderTest;
 
     [TestInitialize]
     public void TestInitialize()

--- a/EPR.Antivirus/EPR.Antivirus.Application/EPR.Antivirus.Application.csproj
+++ b/EPR.Antivirus/EPR.Antivirus.Application/EPR.Antivirus.Application.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Azure.Identity" Version="1.10.4" />
+      <PackageReference Include="Azure.Identity" Version="1.12.0" />
       <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.15.0" />
       <PackageReference Include="Azure.Storage.Blobs" Version="12.17.0" />
       <PackageReference Include="Azure.Storage.Common" Version="12.16.0" />

--- a/EPR.Antivirus/EPR.Antivirus.Application/Extensions/ConfigurationExtensions.cs
+++ b/EPR.Antivirus/EPR.Antivirus.Application/Extensions/ConfigurationExtensions.cs
@@ -15,15 +15,9 @@ public static class ConfigurationExtensions
         bool validate = true)
         where TOptions : class, new()
     {
-        if (services == null)
-        {
-            throw new ArgumentNullException(nameof(services));
-        }
+        ArgumentNullException.ThrowIfNull(services);
 
-        if (sectionKey == null)
-        {
-            throw new ArgumentNullException(nameof(sectionKey));
-        }
+        ArgumentNullException.ThrowIfNull(sectionKey);
 
         services.AddOptions<TOptions>().Configure(delegate(TOptions options, IConfiguration config)
         {

--- a/EPR.Antivirus/EPR.Antivirus.Data/Config/FeatureManagementConfig.cs
+++ b/EPR.Antivirus/EPR.Antivirus.Data/Config/FeatureManagementConfig.cs
@@ -1,5 +1,8 @@
 namespace EPR.Antivirus.Data.Config;
 
+using System.Diagnostics.CodeAnalysis;
+
+[ExcludeFromCodeCoverage]
 public class FeatureManagementConfig
 {
     public const string Section = "FeatureManagement";

--- a/EPR.Antivirus/EPR.Antivirus.Data/EPR.Antivirus.Data.csproj
+++ b/EPR.Antivirus/EPR.Antivirus.Data/EPR.Antivirus.Data.csproj
@@ -5,6 +5,11 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- SonarCloud not aware that a class is to instantiated by DI and therefore it cannot be static. -->
+    <NoWarn>S1118</NoWarn>
+  </PropertyGroup>
+
     <ItemGroup>
       <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
         <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Exclude from Code Coverage because of Compiler Error CS0718: static types cannot be used as type arguments.

The **FeatureManagementConfig** class cannot be made _static_ as suggested by SonarQube because a static type cannot be instantiated, so it cannot be used as a generic argument for a DI call in ConfigurationExtensions.ConfigureOptions() method.
Therefore the warning is suppressed with a pragma.