### PR TITLE
Add fix to R6.1.1 - Save complianceSchemeId to metadata for subsidiaries (#29)

### DIFF
--- a/EPR.Antivirus/EPR.Antivirus.Application.UnitTests/Services/BlobStorageServiceTests.cs
+++ b/EPR.Antivirus/EPR.Antivirus.Application.UnitTests/Services/BlobStorageServiceTests.cs
@@ -69,7 +69,7 @@ public class BlobStorageServiceTests
         var userId = Guid.NewGuid();
         const string csvFileMimeType = "text/csv";
         var submissionPeriod = It.IsAny<string>();
-        string fileName = "testfile.csv";
+        string fileName = "testFile.csv";
         var organisationId = Guid.NewGuid();
 
         // Act
@@ -81,6 +81,7 @@ public class BlobStorageServiceTests
         result.Should().Contain("userId", userId.ToString());
         result.Should().Contain("fileType", csvFileMimeType);
         result.Should().Contain("submissionPeriod", submissionPeriod);
+        result.Should().NotContainKey("complianceSchemeId");
     }
 
     [TestMethod]
@@ -93,7 +94,7 @@ public class BlobStorageServiceTests
         var userId = Guid.NewGuid();
         const string csvFileMimeType = "text/csv";
         var submissionPeriod = "NA";
-        string fileName = "testfile.csv";
+        string fileName = "testFile.csv";
         var organisationId = Guid.NewGuid();
 
         // Act
@@ -106,6 +107,33 @@ public class BlobStorageServiceTests
         result.Should().Contain("fileType", csvFileMimeType);
         result.Should().Contain("fileName", fileName);
         result.Should().Contain("organisationId", organisationId.ToString());
+        result.Should().NotContainKey("complianceSchemeId");
+    }
+
+    [TestMethod]
+    public void CreateMetadata_WhenCalled_ReturnsCorrectMetadata_ForSubsidiariesAndCompaniesHouse_With_ComplianceSchemeId()
+    {
+        // Arrange
+        var fileType = FileType.Subsidiaries;
+        var submissionId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        const string csvFileMimeType = "text/csv";
+        var submissionPeriod = "NA";
+        string fileName = "testFile.csv";
+        var organisationId = Guid.NewGuid();
+        var complianceSchemeId = Guid.NewGuid();
+
+        // Act
+        var result = BlobStorageService.CreateMetadata(submissionId, userId, fileType, submissionPeriod, fileName, organisationId, complianceSchemeId);
+
+        // Assert
+        result.Should().Contain("fileTypeEPR", fileType.ToString());
+        result.Should().Contain("submissionId", submissionId.ToString());
+        result.Should().Contain("userId", userId.ToString());
+        result.Should().Contain("fileType", csvFileMimeType);
+        result.Should().Contain("fileName", fileName);
+        result.Should().Contain("organisationId", organisationId.ToString());
+        result.Should().Contain("complianceSchemeId", complianceSchemeId.ToString());
     }
 
     [TestMethod]

--- a/EPR.Antivirus/EPR.Antivirus.Application/Services/AntiVirusService.cs
+++ b/EPR.Antivirus/EPR.Antivirus.Application/Services/AntiVirusService.cs
@@ -103,7 +103,8 @@ public class AntivirusService : IAntivirusService
             processFileAsyncRequest.FileType,
             processFileAsyncRequest.SubmissionPeriod,
             processFileAsyncRequest.FileName,
-            processFileAsyncRequest.OrganisationId);
+            processFileAsyncRequest.OrganisationId,
+            processFileAsyncRequest.ComplianceSchemeId);
         var blobName = await _blobStorageService.UploadFileStreamWithMetadataAsync(
             fileStream, processFileAsyncRequest.SubmissionType, fileMetadata);
 

--- a/EPR.Antivirus/EPR.Antivirus.Application/Services/BlobStorageService.cs
+++ b/EPR.Antivirus/EPR.Antivirus.Application/Services/BlobStorageService.cs
@@ -21,7 +21,7 @@ public class BlobStorageService : IBlobStorageService
         _logger = logger;
     }
 
-    public static Dictionary<string, string> CreateMetadata(Guid submissionId, Guid userId, FileType fileType, string submissionPeriod, string fileName, Guid organisationId)
+    public static Dictionary<string, string> CreateMetadata(Guid submissionId, Guid userId, FileType fileType, string submissionPeriod, string fileName, Guid organisationId, Guid? complianceSchemeId = null)
     {
         var metaData = new Dictionary<string, string>
         {
@@ -49,6 +49,11 @@ public class BlobStorageService : IBlobStorageService
             default:
                 metaData.Add("submissionPeriod", submissionPeriod);
                 break;
+        }
+
+        if (fileType is FileType.Subsidiaries && complianceSchemeId is not null)
+        {
+            metaData.Add("complianceSchemeId", complianceSchemeId.ToString());
         }
 
         return metaData;


### PR DESCRIPTION
* Save complianceSchemeId to metadata for subsidiaries

* Compliance scheme only set for subsidiaries

Included in R6.1.1 ticket AB#490121